### PR TITLE
Update w2__l4_p1

### DIFF
--- a/edx_MITx_6_00_1x/w2_l4_p1
+++ b/edx_MITx_6_00_1x/w2_l4_p1
@@ -88,8 +88,8 @@ float - correct
 4.0 - correct
 
 d('apple', 11.1)
-boolean - correct
-True - correct
+NoneType - correct
+error - correct
 
 e(a(3), b(4), c(3, 4))
 boolean - correct


### PR DESCRIPTION
In new python, NoneType is there and d('apple', 11.1)
error is the correct one. Not Boolean and true.