### PR TITLE
update according to python 3.5

### DIFF
--- a/edx_MITx_6_00_1x/w2_l4_p2
+++ b/edx_MITx_6_00_1x/w2_l4_p2
@@ -25,7 +25,7 @@ function - correct
 function - correct
 
 b(a, b)
-function - correct
-function - correct
+Nonetype - correct
+error- correct
 
 Perhaps contrary to expectations, in Python it is legal to compare functions!


### PR DESCRIPTION
For the last function call, b(a,b) in Python 3.5 it is illegal to compare functions. 
That's why instead of function its a NoneType and error is correct answer,